### PR TITLE
add ssh_keyfiles feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ into your playbook.
 `users` role was written by:
 - Maciej Delmanowski | [e-mail](mailto:drybjed@gmail.com) | [Twitter](https://twitter.com/drybjed) | [GitHub](https://github.com/drybjed)
 
+Contributions from:
+- Alan Stebbens | [e-mail](mailto:aks@stebbens.org) | [Twitter](https://twitter.com/aks_sba) | [Github](https://github.com/aks)
+
 License: [GPLv3](https://tldrlegal.com/license/gnu-general-public-license-v3-%28gpl-3%29)
 
 ***

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,37 @@ users_group_list: []
 # "Host" users
 users_host_list: []
 
+# The path to the directory containing ssh keyfiles per user
+# The complete path to each ssh keyfile will be:
+#
+#   {{ users_keyfiles_dir }}/{{ keyfilename }}
+#
+# It's typical to have a sub-directory per user, and name the
+# keyfiles like this:
+#
+#  - name: bob
+#    state: present
+#    ssh_keyfiles:
+#      - bob/bob-id_rsa.pub
+#      - bob/aws-dev.pem
+#  - name: susan
+#    state: present
+#    ssh_keyfiles:
+#      - susan/id_rsa.pub
+#  - name: frank
+#    state: present
+#    ssh_keyfiles:
+#      - frank/id_dsa.pub
+#
+# Not every user needs to have the same number of ssh keys, nor
+# do they even need to have one.
+#
+# Note: each user *must* have an "ssh_keyfiles" attribute, unless you have
+# applied the
+# [ignore-missing-subelements](https://github.com/aks/ansible/tree/ignore-missing-subelements)
+# patch to ansible from github, and set the variable `ignore_missing_subelements = True`.
+#
+users_keyfiles_dir:
 
 # --- An example account entry, everything except 'name' is optional
 # List of all recognized values, default value listed first
@@ -60,9 +91,18 @@ users_host_list: []
 #    # Add or disable ssh authorized keys (set to False to remove ~/.ssh/authorized_keys
 #    sshkeys: [ 'list', 'of', 'keys' ]
 #
+#    # or, update authorized keys from the contents from named ssh keyfiles:
+#    ssh_keyfiles:
+#      - username/username-id_rsa.pub
+#      - dev/dev-id_dsa.pub
+#
 #    password: 'krypt pass'         # mkpasswd --method=SHA-512 oder cat /etc/shadow
 #    update_password: 'on_create'   # always will update passwords if they differ.
 #                                   # on_create will only set the password for newly created users. (added in Ansible 1.3)
+#
+# This variable must be defined in order for the `ssh_keyfiles` above to work.
+#
+#users_keyfiles_dir: path/to/your/ssh_keyfiles
 
 
 # --- Global defaults ---

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,6 +38,11 @@ ansigenome_info:
       email: 'drybjed@gmail.com'
       twitter: 'drybjed'
       github: 'drybjed'
+    - name: 'Alan Stebbens'
+      url: ''
+      email: 'aks@stebbens.org'
+      twitter: 'aks_sba'
+      github: 'aks'
 
   synopsis: |
     This role can be used to manage user accounts (and user groups). You can

--- a/tasks/sshkeys.yml
+++ b/tasks/sshkeys.yml
@@ -15,6 +15,20 @@
          (item.state is undefined or (item.state is defined and item.state != 'absent')) and
          (item.sshkeys is defined and item.sshkeys))
 
+- name: Configure authorized SSH keys for users from ssh keyfiles
+  authorized_key:
+    user: '{{ item.0.name }}'
+    key: "{{ lookup('file', users_keyfiles_dir +'/' + item.1) }}"
+    state: 'present'
+  with_subelements:
+    - users_list
+    - ssh_keyfiles
+  when: (users_keyfiles_dir is defined and users_keyfiles_dir and
+         item.1 is defined and item.1                         and
+         item.0.name is defined and item.0.name               and
+         item.0.state is defined and item.0.state != 'absent' and
+         item.0.ssh_keyfiles is defined and item.0.ssh_keyfiles)
+
 - name: Remove ~/.ssh/authorized_keys from user account if disabled
   file:
     path: '{{ item.home | default(users_default_home_prefix + "/" + item.name) }}/.ssh/authorized_keys'
@@ -26,6 +40,7 @@
     - users_group_list
     - users_host_list
   when: ((item.name is defined and item.name != 'root') and
-         (item.state is undefined or (item.state is defined and item.state != 'absent')) and
-         (item.sshkeys is defined and not item.sshkeys))
+         (item.state is undefined or item.state is defined and item.state != 'absent') and
+         ((item.sshkeys is defined and item.sshkeys == False) or
+          (item.ssh_keyfiles is not defined or item.ssh_keyfiles == [])))
 


### PR DESCRIPTION
This change implements a new feature: the `ssh_keyfiles` attribute in the `users_list`.  That is, instead of (or in addition to) providing ssh public keys via the `ssh_keys` list, ssh public keys can be added by referring to one or more filenames on the `ssh_keyfiles` key.

This patch uses the `with_subelements` loop control, which currently (at the time of this writing) requires that every item in the dict has an instance of the named key attribute.  This means that every user must have a `ssh_keyfiles` defined, even if its empty: `[]`. 

However, a [patch to ansible](http://stackoverflow.com/questions/24616107/ansible-with-subelements-default-value) has been submitted to allow for gracefully skipping items for which there is no corresponding `ssh_keyfiles` key.  If this patch is merged into the ansible source, then it will be possible to set a configuration called `ignore_missing_subelements` which will allow user items in `users_list` to be ignored if they do not have the requisite `ssh_keyfiles`.