### PR TITLE
Add support for users_default_shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 
+sudo: True
 language: 'python'
 python: '2.7'
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -26,7 +26,7 @@
     password: '{{ item.password | default("*") }}'
     update_password: '{{ item.update_password | default("on_create") }}'
     system: '{{ item.system | default(omit) }}'
-    shell: '{{ item.shell | default(omit) }}'
+    shell: '{{ item.shell | default(users_default_shell) | default(omit) }}'
     home: '{{ item.home | default(omit) }}'
     createhome: '{{ item.createhome | default(omit) }}'
     expires: '{{ item.expires | default(omit) }}'


### PR DESCRIPTION
[Documentation](http://docs.debops.org/en/latest/ansible/roles/debops.users.html) mentions default settings like `users_default_shell`. Unfortunately they are not implemented. This is implementation of `users_default_shell`. There is also small change in Travis configuration preventing use of containers and enabling `sudo` support.