### PR TITLE
Get list of available groups even in Ansible check mode to avoid error.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Get list of available groups even in Ansible check mode to avoid error. [ypid]
+
 v0.1.3
 ------
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -64,6 +64,7 @@
   shell: 'getent group | cut -f1 -d:'
   register: users_register_groups
   changed_when: False
+  always_run: yes
 
 - name: Manage user default groups
   user:


### PR DESCRIPTION
Error:
TASK: [debops.users | Manage user groups] *************************************
fatal: [localhost] => Failed to template {{ (item.groups | intersect(users_register_groups.stdout_lines)) | join(",") }}: Unable to look up a name or access an attribute in template string. Make sure your variable name does not contain invalid characters like '-'.