### PR TITLE
fix authorized_keys /n

### DIFF
--- a/tasks/sshkeys.yml
+++ b/tasks/sshkeys.yml
@@ -2,7 +2,7 @@
 
 - name: Configure ~/.ssh/authorized_keys for users
   authorized_key:
-    key: '{{ "\n".join(item.sshkeys) | string }}'
+    key: "{{ '\n'.join(item.sshkeys) | string }}"
     state: 'present'
     user: '{{ item.name }}'
   with_flattened:


### PR DESCRIPTION
When I add more keys, they all merge into one line.
```
ssh-key ....\n ssh-key ....
```