### PR TITLE
Add support for 'users__dependent_groups|accounts' variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ The current role maintainer_ is drybjed.
 
 .. _debops.users master: https://github.com/debops/ansible-users/compare/v0.2.1...master
 
+Added
+~~~~~
+
+- Added new variables :envvar:`users__dependent_accounts` and
+  :envvar:`users__dependent_groups` making the role usable for other roles
+  which require more sophisticated user account setups. [ganto_]
+
 
 `debops.users v0.2.1`_ - 2016-10-16
 -----------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,15 @@ users__group_groups: []
 #
 # List of UNIX groups to manage on specific hosts in Ansible inventory.
 users__host_groups: []
+
+                                                                   # ]]]
+# .. envvar:: users__dependent_groups [[[
+#
+# List of UNIX groups to manage on the current playbook host. This variable is
+# meant to be used from a role dependency in :file:`role/meta/main.yml` or in
+# a playbook.
+users__dependent_groups: []
+
                                                                    # ]]]
                                                                    # ]]]
 # Lists of managed UNIX accounts [[[
@@ -115,6 +124,14 @@ users__default_accounts: []
 # List of UNIX administrator accounts managed by Ansible.
 users__admin_accounts: '{{ lookup("template", "lookup/users__admin_accounts.j2") | from_yaml }}'
                                                                    # ]]]
+                                                                   # ]]]
+# .. envvar:: users__dependent_accounts [[[
+#
+# List of user accounts to manage on the current playbook host. This variable
+# is meant to be used from a role dependency in :file:`role/meta/main.yml` or
+# in a playbook.
+users__dependent_accounts: []
+
                                                                    # ]]]
 # Management of user resources [[[
 # --------------------------------

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -13,6 +13,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.state|d('present') != 'absent' and item.createhome|d(True) and
          item.dotfiles_enabled | d(users__dotfiles_enabled) | bool)
   no_log: '{{ users__no_log | bool }}'
@@ -37,6 +38,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.state|d('present') != 'absent' and item.createhome|d(True) and
          item.dotfiles_enabled | d(users__dotfiles_enabled) | bool and
          item.dotfiles_command | d(users__dotfiles_combined_map[item.dotfiles_name | d(users__dotfiles_name)].command|d()))
@@ -53,6 +55,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.state|d('present') != 'absent' and item.createhome|d(True) and
          (item.dotfiles_enabled | d(users__dotfiles_enabled) | bool or item.shell|d() or users__default_shell))
   no_log: '{{ users__no_log | bool }}'

--- a/tasks/forward.yml
+++ b/tasks/forward.yml
@@ -14,6 +14,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.name != 'root' and item.state|d('present') != 'absent' and
          item.createhome|d(True) and item.forward|d())
   no_log: '{{ users__no_log | bool }}'

--- a/tasks/sshkeys.yml
+++ b/tasks/sshkeys.yml
@@ -13,6 +13,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.state|d('present') != 'absent' and item.createhome|d(True) and
          item.sshkeys|d() and item.sshkeys_state|d('present') != 'absent')
   no_log: '{{ users__no_log | bool }}'
@@ -29,6 +30,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.state|d('present') != 'absent' and item.createhome|d(True) and
          item.sshkeys_state|d('present') == 'absent')
   no_log: '{{ users__no_log | bool }}'

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,11 +10,13 @@
     - '{{ users__groups }}'
     - '{{ users__group_groups }}'
     - '{{ users__host_groups }}'
+    - '{{ users__dependent_groups }}'
     - '{{ users__default_accounts }}'
     - '{{ users__admin_accounts }}'
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.name != 'root' and item.state|d('present') != 'absent')
   no_log: '{{ users__no_log | bool }}'
 
@@ -55,6 +57,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.name != 'root')
   no_log: '{{ users__no_log | bool }}'
 
@@ -71,6 +74,7 @@
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.name != 'root' and item.state|d('present') != 'absent' and item.createhome|d(True) and
          (item.home_owner|d() or item.home_group|d() or item.home_mode|d()))
   no_log: '{{ users__no_log | bool }}'
@@ -83,11 +87,13 @@
     - '{{ users__groups }}'
     - '{{ users__group_groups }}'
     - '{{ users__host_groups }}'
+    - '{{ users__dependent_groups }}'
     - '{{ users__default_accounts }}'
     - '{{ users__admin_accounts }}'
     - '{{ users__accounts }}'
     - '{{ users__group_accounts }}'
     - '{{ users__host_accounts }}'
+    - '{{ users__dependent_accounts }}'
   when: (item.name|d() and item.name != 'root' and item.state|d('present') == 'absent' and
          (item.group is undefined or item.group == item.name))
   no_log: '{{ users__no_log | bool }}'


### PR DESCRIPTION
Allow other roles to define users/groups which will then be managed via `debops.users`. This is currently used by `debops-contrib/checkmk_server` to manage the site account keys used for SSH-based monitoring. E.g. https://github.com/debops-contrib/ansible-checkmk_server/pull/53/files#diff-e9d6cde642439f4c4d7b465d06b6db65R32