### PR TITLE
Omit group variable if not defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ Added
   :envvar:`users__dependent_groups` making the role usable for other roles
   which require more sophisticated user account setups. [ganto_]
 
+Changed
+~~~~~~~
+
+- Omit ``group`` parameter of :envvar:`users__accounts` by default.
+  Previously, it was set to username by default. [tootoonchian_]
+
 
 `debops.users v0.2.1`_ - 2016-10-16
 -----------------------------------

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -28,7 +28,7 @@
   user:
     name:               '{{ item.name }}'
     uid:                '{{ item.uid                | d(omit) }}'
-    group:              '{{ item.group              | d(item.name) }}'
+    group:              '{{ item.group              | d(omit) }}'
     groups:             '{{ ( (([ item.groups ] if item.groups is string else item.groups) | intersect(getent_group.keys())) | join(",") ) if item.groups is defined else omit }}'
     append:             '{{ item.append             | d(True) }}'
     state:              '{{ item.state              | d("present") }}'


### PR DESCRIPTION
useradd has a default behavior when the primary gid is not specified (per /etc/login.defs and /etc/default). Using item.name when group is unspecified overrides that default behavior.

Moreover, this omission by default enables users__accounts to add non-local users (missing from /etc/passwd) to local groups, whereas currently it errors out with "usermod: user ... does not exist in /etc/passwd".