### PR TITLE
Replacing "become_user" by "path: ~{{item.name}}/.ssh/authorized_keys"

### DIFF
--- a/tasks/sshkeys.yml
+++ b/tasks/sshkeys.yml
@@ -20,10 +20,8 @@
 
 - name: Remove ~/.ssh/authorized_keys from user account if disabled
   file:
-    path: '~/.ssh/authorized_keys'
+    path: '~{{ item.name }}/.ssh/authorized_keys'
     state: 'absent'
-  become_user: '{{ item.name }}'
-  become: True
   with_flattened:
     - '{{ users__root_accounts }}'
     - '{{ users__default_accounts }}'


### PR DESCRIPTION
When trying this task (with `become_user`) on some machines, I get this error:
`"Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: modification du propriétaire de '/tmp/ansible-tmp-1512551695.33-17427842928627/': Opération non permise\nchown: modification du propriétaire de '/tmp/ansible-tmp-1512551695.33-17427842928627/file.py': Opération non permise\n}). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"`
This change fixes it.